### PR TITLE
Emit versioned .so by default

### DIFF
--- a/cargo-pgx/src/commands/get.rs
+++ b/cargo-pgx/src/commands/get.rs
@@ -59,24 +59,7 @@ pub fn get_property(name: &str) -> Option<String> {
 }
 
 pub(crate) fn find_control_file() -> (PathBuf, String) {
-    for f in handle_result!(
-        std::fs::read_dir("."),
-        "cannot open current directory for reading"
-    ) {
-        if f.is_ok() {
-            if let Ok(f) = f {
-                if f.file_name().to_string_lossy().ends_with(".control") {
-                    let filename = f.file_name().into_string().unwrap();
-                    let mut extname: Vec<&str> = filename.split('.').collect();
-                    extname.pop();
-                    let extname = extname.pop().unwrap();
-                    return (filename.clone().into(), extname.to_string());
-                }
-            }
-        }
-    }
-
-    exit_with_error!("control file not found in current directory")
+    handle_result!(pgx_utils::find_control_file(), "cannot find control file")
 }
 
 fn determine_git_hash() -> Option<String> {

--- a/cargo-pgx/src/commands/install.rs
+++ b/cargo-pgx/src/commands/install.rs
@@ -79,6 +79,7 @@ pub(crate) fn install_extension(
     let pkgdir = make_relative(pg_config.pkglibdir()?);
     let extdir = make_relative(pg_config.extension_dir()?);
     let shlibpath = find_library_file(&extname, is_release);
+    let extver = get_version();
 
     {
         let mut dest = base_directory.clone();
@@ -90,7 +91,7 @@ pub(crate) fn install_extension(
     {
         let mut dest = base_directory.clone();
         dest.push(&pkgdir);
-        dest.push(format!("{}.so", extname));
+        dest.push(format!("{}-{}.so", extname, extver));
 
         if cfg!(target_os = "macos") {
             // Remove the existing .so if present. This is a workaround for an

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -565,6 +565,27 @@ pub fn anonymonize_lifetimes(value: &mut syn::Type) {
     }
 }
 
+pub fn find_control_file() -> Result<(PathBuf, String), std::io::Error> {
+    let dir = std::fs::read_dir(".")?;
+    for f in dir {
+        if f.is_ok() {
+            if let Ok(f) = f {
+                if f.file_name().to_string_lossy().ends_with(".control") {
+                    let filename = f.file_name().into_string().unwrap();
+                    let mut extname: Vec<&str> = filename.split('.').collect();
+                    extname.pop();
+                    let extname = extname.pop().unwrap();
+                    return Ok((filename.clone().into(), extname.to_string()));
+                }
+            }
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "control file not found in current directory",
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{parse_extern_attributes, ExternArgs};

--- a/pgx/src/datum/sql_entity_graph/pgx_sql.rs
+++ b/pgx/src/datum/sql_entity_graph/pgx_sql.rs
@@ -43,6 +43,7 @@ pub struct PgxSql {
     pub enums: HashMap<PostgresEnumEntity, NodeIndex>,
     pub ords: HashMap<PostgresOrdEntity, NodeIndex>,
     pub hashes: HashMap<PostgresHashEntity, NodeIndex>,
+    pub extension_name: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
@@ -58,6 +59,7 @@ impl PgxSql {
         type_mappings: impl Iterator<Item = RustSqlMapping>,
         source_mappings: impl Iterator<Item = RustSourceOnlySqlMapping>,
         entities: impl Iterator<Item = SqlGraphEntity>,
+        extension_name: String,
     ) -> eyre::Result<Self> {
         let mut graph = StableGraph::new();
 
@@ -184,6 +186,7 @@ impl PgxSql {
             graph_root: root,
             graph_bootstrap: bootstrap,
             graph_finalize: finalize,
+            extension_name: extension_name,
         };
         this.register_types();
         Ok(this)

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -92,6 +92,8 @@ pub use pgx_pg_sys as pg_sys; // the module only, not its contents
 pub use pgx_pg_sys::submodules::*;
 pub use pgx_pg_sys::PgBuiltInOids; // reexport this so it looks like it comes from here
 
+pub use pgx_utils::find_control_file; // reexport so that we can use it from macros
+
 use core::any::TypeId;
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
@@ -484,10 +486,13 @@ macro_rules! pg_binary_magic {
                 }
             };
 
+            let (_, extname) = pgx::find_control_file().expect("Couldn't read control file");
+
             let pgx_sql = PgxSql::build(
                 pgx::DEFAULT_TYPEID_SQL_MAPPING.clone().into_iter(),
                 pgx::DEFAULT_SOURCE_ONLY_SQL_MAPPING.clone().into_iter(),
-                entities.into_iter()).unwrap();
+                entities.into_iter(),
+                extname).unwrap();
 
             tracing::info!(path = %path.display(), "Writing SQL");
             pgx_sql.to_file(path)?;


### PR DESCRIPTION
There is an implicit requirement that C extensions maintain ABI
compatibility between versions. Emitting a versioned .so allows for ABI
breaks between versions. The generated now SQL points to the versioned
.so file.

It does also require that care is taken in the following scenarios:
- when using shared memory
- when using query planner hooks
- when producing SQL schema migrations