### PR TITLE
feat: extend sql generation via to_sql attribute

### DIFF
--- a/pgx-macros/src/operators.rs
+++ b/pgx-macros/src/operators.rs
@@ -11,7 +11,10 @@ pub(crate) fn impl_postgres_eq(ast: DeriveInput) -> proc_macro2::TokenStream {
     stream
 }
 
-pub(crate) fn impl_postgres_ord(ast: DeriveInput) -> proc_macro2::TokenStream {
+pub(crate) fn impl_postgres_ord(
+    ast: DeriveInput,
+    to_sql_config: sql_entity_graph::ToSqlConfig,
+) -> proc_macro2::TokenStream {
     let mut stream = proc_macro2::TokenStream::new();
 
     stream.extend(lt(&ast.ident));
@@ -20,18 +23,23 @@ pub(crate) fn impl_postgres_ord(ast: DeriveInput) -> proc_macro2::TokenStream {
     stream.extend(ge(&ast.ident));
     stream.extend(cmp(&ast.ident));
 
-    let sql_graph_entity_item = sql_entity_graph::PostgresOrd::new(ast.ident.clone());
+    let sql_graph_entity_item =
+        sql_entity_graph::PostgresOrd::new(ast.ident.clone(), to_sql_config);
     sql_graph_entity_item.to_tokens(&mut stream);
 
     stream
 }
 
-pub(crate) fn impl_postgres_hash(ast: DeriveInput) -> proc_macro2::TokenStream {
+pub(crate) fn impl_postgres_hash(
+    ast: DeriveInput,
+    to_sql_config: sql_entity_graph::ToSqlConfig,
+) -> proc_macro2::TokenStream {
     let mut stream = proc_macro2::TokenStream::new();
 
     stream.extend(hash(&ast.ident));
 
-    let sql_graph_entity_item = sql_entity_graph::PostgresHash::new(ast.ident.clone());
+    let sql_graph_entity_item =
+        sql_entity_graph::PostgresHash::new(ast.ident.clone(), to_sql_config);
     sql_graph_entity_item.to_tokens(&mut stream);
 
     stream

--- a/pgx-utils/src/sql_entity_graph/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/mod.rs
@@ -7,6 +7,7 @@ mod postgres_enum;
 mod postgres_hash;
 mod postgres_ord;
 mod postgres_type;
+mod to_sql;
 
 pub use super::ExternArgs;
 pub use extension_sql::{ExtensionSql, ExtensionSqlFile, SqlDeclared};
@@ -18,6 +19,7 @@ pub use postgres_enum::PostgresEnum;
 pub use postgres_hash::PostgresHash;
 pub use postgres_ord::PostgresOrd;
 pub use postgres_type::PostgresType;
+pub use to_sql::ToSqlConfig;
 
 /// Reexports for the pgx SQL generator binaries.
 #[doc(hidden)]

--- a/pgx-utils/src/sql_entity_graph/pg_aggregate/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_aggregate/mod.rs
@@ -14,6 +14,8 @@ use syn::{
     Expr,
 };
 
+use super::ToSqlConfig;
+
 // We support only 32 tuples...
 const ARG_NAMES: [&str; 32] = [
     "arg_one",
@@ -77,10 +79,12 @@ pub struct PgAggregate {
     fn_moving_state_inverse: Option<Ident>,
     fn_moving_finalize: Option<Ident>,
     hypothetical: bool,
+    to_sql_config: ToSqlConfig,
 }
 
 impl PgAggregate {
     pub fn new(mut item_impl: ItemImpl) -> Result<Self, syn::Error> {
+        let to_sql_config = ToSqlConfig::from_attributes(item_impl.attrs.as_slice())?.unwrap_or_default();
         let target_path = get_target_path(&item_impl)?;
         let target_ident = get_target_ident(&target_path)?;
         let snake_case_target_ident = Ident::new(
@@ -495,6 +499,7 @@ impl PgAggregate {
             } else {
                 false
             },
+            to_sql_config,
         })
     }
 
@@ -533,6 +538,7 @@ impl PgAggregate {
         let fn_moving_state_iter = self.fn_moving_state.iter();
         let fn_moving_state_inverse_iter = self.fn_moving_state_inverse.iter();
         let fn_moving_finalize_iter = self.fn_moving_finalize.iter();
+        let to_sql_config = &self.to_sql_config;
 
         let entity_item_fn: ItemFn = parse_quote! {
             #[no_mangle]
@@ -567,6 +573,7 @@ impl PgAggregate {
                     sortop: None#( .unwrap_or(Some(#const_sort_operator_iter)) )*,
                     parallel: None#( .unwrap_or(#const_parallel_iter) )*,
                     hypothetical: #hypothetical,
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Aggregate(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/postgres_enum.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum.rs
@@ -6,6 +6,8 @@ use syn::{
 };
 use syn::{punctuated::Punctuated, Ident, Token};
 
+use super::ToSqlConfig;
+
 /// A parsed `#[derive(PostgresEnum)]` item.
 ///
 /// It should be used with [`syn::parse::Parse`] functions.
@@ -33,6 +35,7 @@ pub struct PostgresEnum {
     name: Ident,
     generics: Generics,
     variants: Punctuated<syn::Variant, Token![,]>,
+    to_sql_config: ToSqlConfig,
 }
 
 impl PostgresEnum {
@@ -40,15 +43,19 @@ impl PostgresEnum {
         name: Ident,
         generics: Generics,
         variants: Punctuated<syn::Variant, Token![,]>,
+        to_sql_config: ToSqlConfig,
     ) -> Self {
         Self {
             name,
             generics,
             variants,
+            to_sql_config,
         }
     }
 
     pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
         let data_enum = match derive_input.data {
             syn::Data::Enum(data_enum) => data_enum,
             syn::Data::Union(_) | syn::Data::Struct(_) => {
@@ -59,6 +66,7 @@ impl PostgresEnum {
             derive_input.ident,
             derive_input.generics,
             data_enum.variants,
+            to_sql_config,
         ))
     }
 }
@@ -66,7 +74,14 @@ impl PostgresEnum {
 impl Parse for PostgresEnum {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let parsed: ItemEnum = input.parse()?;
-        Ok(Self::new(parsed.ident, parsed.generics, parsed.variants))
+        let to_sql_config =
+            ToSqlConfig::from_attributes(parsed.attrs.as_slice())?.unwrap_or_default();
+        Ok(Self::new(
+            parsed.ident,
+            parsed.generics,
+            parsed.variants,
+            to_sql_config,
+        ))
     }
 }
 
@@ -83,6 +98,8 @@ impl ToTokens for PostgresEnum {
         let variants = self.variants.iter();
         let sql_graph_entity_fn_name =
             syn::Ident::new(&format!("__pgx_internals_enum_{}", name), Span::call_site());
+
+        let to_sql_config = &self.to_sql_config;
 
         let inv = quote! {
             #[no_mangle]
@@ -101,6 +118,7 @@ impl ToTokens for PostgresEnum {
                     full_path: core::any::type_name::<#name #ty_generics>(),
                     mappings,
                     variants: vec![ #(  stringify!(#variants)  ),* ],
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Enum(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/postgres_hash.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash.rs
@@ -2,8 +2,10 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseStream},
-    DeriveInput, Ident, ItemEnum, ItemStruct,
+    DeriveInput, Ident,
 };
+
+use super::ToSqlConfig;
 
 /// A parsed `#[derive(PostgresHash)]` item.
 ///
@@ -51,27 +53,36 @@ use syn::{
 #[derive(Debug, Clone)]
 pub struct PostgresHash {
     pub name: Ident,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl PostgresHash {
-    pub fn new(name: Ident) -> Self {
-        Self { name }
+    pub fn new(name: Ident, to_sql_config: ToSqlConfig) -> Self {
+        Self {
+            name,
+            to_sql_config,
+        }
     }
 
     pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
-        Ok(Self::new(derive_input.ident))
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
+        Ok(Self::new(derive_input.ident, to_sql_config))
     }
 }
 
 impl Parse for PostgresHash {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let parsed_enum: Result<ItemEnum, syn::Error> = input.parse();
-        let parsed_struct: Result<ItemStruct, syn::Error> = input.parse();
-        let ident = parsed_enum
-            .map(|x| x.ident)
-            .or_else(|_| parsed_struct.map(|x| x.ident))
-            .map_err(|_| syn::Error::new(input.span(), "expected enum or struct"))?;
-        Ok(Self::new(ident))
+        use syn::Item;
+
+        let parsed = input.parse()?;
+        let (ident, attrs) = match &parsed {
+            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
+            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
+            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
+        };
+        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
+        Ok(Self::new(ident, to_sql_config))
     }
 }
 
@@ -82,6 +93,7 @@ impl ToTokens for PostgresHash {
             &format!("__pgx_internals_hash_{}", self.name),
             Span::call_site(),
         );
+        let to_sql_config = &self.to_sql_config;
         let inv = quote! {
             #[no_mangle]
             pub extern "C" fn  #sql_graph_entity_fn_name() -> pgx::datum::sql_entity_graph::SqlGraphEntity {
@@ -93,6 +105,7 @@ impl ToTokens for PostgresHash {
                     full_path: core::any::type_name::<#name>(),
                     module_path: module_path!(),
                     id: TypeId::of::<#name>(),
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Hash(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/postgres_ord.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord.rs
@@ -2,8 +2,10 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseStream},
-    DeriveInput, Ident, ItemEnum, ItemStruct,
+    DeriveInput, Ident,
 };
+
+use super::ToSqlConfig;
 
 /// A parsed `#[derive(PostgresOrd)]` item.
 ///
@@ -51,27 +53,36 @@ use syn::{
 #[derive(Debug, Clone)]
 pub struct PostgresOrd {
     pub name: Ident,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl PostgresOrd {
-    pub fn new(name: Ident) -> Self {
-        Self { name }
+    pub fn new(name: Ident, to_sql_config: ToSqlConfig) -> Self {
+        Self {
+            name,
+            to_sql_config,
+        }
     }
 
     pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
-        Ok(Self::new(derive_input.ident))
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
+        Ok(Self::new(derive_input.ident, to_sql_config))
     }
 }
 
 impl Parse for PostgresOrd {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let parsed_enum: Result<ItemEnum, syn::Error> = input.parse();
-        let parsed_struct: Result<ItemStruct, syn::Error> = input.parse();
-        let ident = parsed_enum
-            .map(|x| x.ident)
-            .or_else(|_| parsed_struct.map(|x| x.ident))
-            .map_err(|_| syn::Error::new(input.span(), "expected enum or struct"))?;
-        Ok(Self::new(ident))
+        use syn::Item;
+
+        let parsed = input.parse()?;
+        let (ident, attrs) = match &parsed {
+            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
+            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
+            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
+        };
+        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
+        Ok(Self::new(ident, to_sql_config))
     }
 }
 
@@ -82,6 +93,7 @@ impl ToTokens for PostgresOrd {
             &format!("__pgx_internals_ord_{}", self.name),
             Span::call_site(),
         );
+        let to_sql_config = &self.to_sql_config;
         let inv = quote! {
             #[no_mangle]
             pub extern "C" fn  #sql_graph_entity_fn_name() -> pgx::datum::sql_entity_graph::SqlGraphEntity {
@@ -93,6 +105,7 @@ impl ToTokens for PostgresOrd {
                     full_path: core::any::type_name::<#name>(),
                     module_path: module_path!(),
                     id: TypeId::of::<#name>(),
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Ord(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/postgres_type.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type.rs
@@ -9,6 +9,8 @@ use syn::{
     DeriveInput, Generics, ItemStruct,
 };
 
+use super::ToSqlConfig;
+
 /// A parsed `#[derive(PostgresType)]` item.
 ///
 /// It should be used with [`syn::parse::Parse`] functions.
@@ -37,15 +39,23 @@ pub struct PostgresType {
     generics: Generics,
     in_fn: Ident,
     out_fn: Ident,
+    to_sql_config: ToSqlConfig,
 }
 
 impl PostgresType {
-    pub fn new(name: Ident, generics: Generics, in_fn: Ident, out_fn: Ident) -> Self {
+    pub fn new(
+        name: Ident,
+        generics: Generics,
+        in_fn: Ident,
+        out_fn: Ident,
+        to_sql_config: ToSqlConfig,
+    ) -> Self {
         Self {
             generics,
             name,
             in_fn,
             out_fn,
+            to_sql_config,
         }
     }
 
@@ -59,6 +69,8 @@ impl PostgresType {
                 ))
             }
         };
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
         let funcname_in = Ident::new(
             &format!("{}_in", derive_input.ident).to_lowercase(),
             derive_input.ident.span(),
@@ -72,6 +84,7 @@ impl PostgresType {
             derive_input.generics,
             funcname_in,
             funcname_out,
+            to_sql_config,
         ))
     }
 
@@ -93,6 +106,8 @@ impl PostgresType {
 impl Parse for PostgresType {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let parsed: ItemStruct = input.parse()?;
+        let to_sql_config =
+            ToSqlConfig::from_attributes(parsed.attrs.as_slice())?.unwrap_or_default();
         let funcname_in = Ident::new(
             &format!("{}_in", parsed.ident).to_lowercase(),
             parsed.ident.span(),
@@ -106,6 +121,7 @@ impl Parse for PostgresType {
             parsed.generics,
             funcname_in,
             funcname_out,
+            to_sql_config,
         ))
     }
 }
@@ -126,6 +142,8 @@ impl ToTokens for PostgresType {
             &format!("__pgx_internals_type_{}", self.name),
             Span::call_site(),
         );
+
+        let to_sql_config = &self.to_sql_config;
 
         let inv = quote! {
             #[no_mangle]
@@ -167,7 +185,8 @@ impl ToTokens for PostgresType {
                         let mut path_items: Vec<_> = out_fn.split("::").collect();
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
-                    }
+                    },
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Type(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/to_sql.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql.rs
@@ -1,0 +1,96 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::spanned::Spanned;
+use syn::{AttrStyle, Attribute, Lit, Meta, MetaList, NestedMeta};
+
+#[derive(Debug, Clone)]
+pub struct ToSqlConfig {
+    enabled: bool,
+    callback: Option<syn::Path>,
+}
+impl Default for ToSqlConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            callback: None,
+        }
+    }
+}
+
+const INVALID_ATTR_CONTENT: &str =
+    "expected either #[to_sql(bool)] or #[to_sql(path::to::callback)]";
+
+impl ToSqlConfig {
+    /// Used for general purpose parsing from an attribute
+    pub fn from_attribute(attr: &Attribute) -> Result<Self, syn::Error> {
+        if attr.style != AttrStyle::Outer {
+            return Err(syn::Error::new(
+                attr.span(),
+                "#[to_sql(..)] is only valid in an outer context",
+            ));
+        }
+
+        let mut enabled = true;
+        let mut callback: Option<syn::Path> = None;
+
+        match attr.parse_meta()? {
+            Meta::List(MetaList { nested, .. }) => {
+                let meta = nested.first().ok_or_else(|| {
+                    syn::Error::new(nested.span(), "expected non-empty argument list")
+                })?;
+                if nested.len() > 1 {
+                    return Err(syn::Error::new(nested.span(), INVALID_ATTR_CONTENT));
+                }
+                match meta {
+                    NestedMeta::Lit(Lit::Bool(b)) => {
+                        enabled = b.value;
+                    }
+                    NestedMeta::Lit(lit) => {
+                        return Err(syn::Error::new(lit.span(), INVALID_ATTR_CONTENT))
+                    }
+                    NestedMeta::Meta(Meta::Path(callback_path)) => {
+                        callback = Some(callback_path.clone());
+                    }
+                    NestedMeta::Meta(meta) => {
+                        return Err(syn::Error::new(meta.span(), INVALID_ATTR_CONTENT))
+                    }
+                }
+            }
+            _ => return Err(syn::Error::new(attr.span(), "expected argument list")),
+        }
+
+        Ok(Self { enabled, callback })
+    }
+
+    /// Used to parse a generator config from a set of item attributes
+    pub fn from_attributes(attrs: &[Attribute]) -> Result<Option<Self>, syn::Error> {
+        if let Some(attr) = attrs.iter().find(|attr| attr.path.is_ident("to_sql")) {
+            Self::from_attribute(attr).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl ToTokens for ToSqlConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let enabled = self.enabled;
+        let callback = &self.callback;
+        let quoted = if let Some(callback_path) = callback {
+            quote! {
+                ::pgx::datum::sql_entity_graph::ToSqlConfig {
+                    enabled: #enabled,
+                    callback: Some(#callback_path),
+                }
+            }
+        } else {
+            quote! {
+                ::pgx::datum::sql_entity_graph::ToSqlConfig {
+                    enabled: #enabled,
+                    callback: None,
+                }
+            }
+        };
+        tokens.append_all(quoted);
+    }
+}

--- a/pgx/src/datum/sql_entity_graph/aggregate.rs
+++ b/pgx/src/datum/sql_entity_graph/aggregate.rs
@@ -1,6 +1,6 @@
 use crate::{
     aggregate::{FinalizeModify, ParallelOption},
-    datum::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier, ToSql},
+    datum::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfig},
 };
 use core::{any::TypeId, cmp::Ordering};
 use eyre::eyre as eyre_err;
@@ -126,6 +126,7 @@ pub struct PgAggregateEntity {
     ///
     /// Corresponds to `hypothetical` in [`crate::aggregate::Aggregate`].
     pub hypothetical: bool,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl Ord for PgAggregateEntity {
@@ -240,7 +241,7 @@ impl ToSql for PgAggregateEntity {
             "\n\
                 -- {file}:{line}\n\
                 -- {full_path}\n\
-                CREATE AGGREGATE {schema}{name} ({args}{maybe_order_by})\n\
+                CREATE OR REPLACE AGGREGATE {schema}{name} ({args}{maybe_order_by})\n\
                 (\n\
                     \tSFUNC = {schema}\"{sfunc}\",\n\
                     \tSTYPE = {schema}{stype}{maybe_comma_after_stype} /* {stype_full_path} */\

--- a/pgx/src/datum/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx/src/datum/sql_entity_graph/pg_extern/mod.rs
@@ -10,7 +10,7 @@ pub use returning::PgExternReturnEntity;
 
 use pgx_utils::ExternArgs;
 
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfig};
 use pgx_utils::sql_entity_graph::SqlDeclared;
 use std::cmp::Ordering;
 
@@ -30,6 +30,7 @@ pub struct PgExternEntity {
     pub fn_return: PgExternReturnEntity,
     pub operator: Option<PgOperatorEntity>,
     pub overridden: Option<&'static str>,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl Ord for PgExternEntity {

--- a/pgx/src/datum/sql_entity_graph/postgres_enum.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_enum.rs
@@ -3,7 +3,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfig};
 
 /// The output of a [`PostgresEnum`](crate::datum::sql_entity_graph::PostgresEnum) from `quote::ToTokens::to_tokens`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +15,7 @@ pub struct PostgresEnumEntity {
     pub module_path: &'static str,
     pub mappings: std::collections::HashSet<super::RustSqlMapping>,
     pub variants: Vec<&'static str>,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl Hash for PostgresEnumEntity {

--- a/pgx/src/datum/sql_entity_graph/postgres_hash.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_hash.rs
@@ -1,4 +1,4 @@
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfig};
 use std::cmp::Ordering;
 
 /// The output of a [`PostgresHash`](crate::datum::sql_entity_graph::PostgresHash) from `quote::ToTokens::to_tokens`.
@@ -10,6 +10,7 @@ pub struct PostgresHashEntity {
     pub full_path: &'static str,
     pub module_path: &'static str,
     pub id: core::any::TypeId,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl Ord for PostgresHashEntity {

--- a/pgx/src/datum/sql_entity_graph/postgres_ord.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_ord.rs
@@ -1,4 +1,4 @@
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfig};
 use std::cmp::Ordering;
 
 /// The output of a [`PostgresOrd`](crate::datum::sql_entity_graph::PostgresOrd) from `quote::ToTokens::to_tokens`.
@@ -10,6 +10,7 @@ pub struct PostgresOrdEntity {
     pub full_path: &'static str,
     pub module_path: &'static str,
     pub id: core::any::TypeId,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl Ord for PostgresOrdEntity {

--- a/pgx/src/datum/sql_entity_graph/postgres_type.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_type.rs
@@ -5,7 +5,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfig};
 
 /// The output of a [`PostgresType`](crate::datum::sql_entity_graph::PostgresType) from `quote::ToTokens::to_tokens`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +20,7 @@ pub struct PostgresTypeEntity {
     pub in_fn_module_path: String,
     pub out_fn: &'static str,
     pub out_fn_module_path: String,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl Hash for PostgresTypeEntity {

--- a/pgx/src/datum/sql_entity_graph/sql_graph_entity.rs
+++ b/pgx/src/datum/sql_entity_graph/sql_graph_entity.rs
@@ -110,13 +110,54 @@ impl ToSql for SqlGraphEntity {
                 }
             }) {
                 Ok(String::default())
-            } else { item.to_sql(context) },
-            SqlGraphEntity::Type(item) => item.to_sql(context),
+            } else if let Some(callback) = item.to_sql_config.callback {
+                callback(self, context)
+            } else if item.to_sql_config.enabled {
+                item.to_sql(context)
+            } else {
+                Ok(String::default())
+            },
+            SqlGraphEntity::Type(item) if !item.to_sql_config.enabled => Ok(String::default()),
+            SqlGraphEntity::Type(item) => {
+                if let Some(callback) = item.to_sql_config.callback {
+                    callback(self, context)
+                } else {
+                    item.to_sql(context)
+                }
+            }
             SqlGraphEntity::BuiltinType(_) => Ok(String::default()),
-            SqlGraphEntity::Enum(item) => item.to_sql(context),
-            SqlGraphEntity::Ord(item) => item.to_sql(context),
-            SqlGraphEntity::Hash(item) => item.to_sql(context),
-            SqlGraphEntity::Aggregate(item) => item.to_sql(context),
+            SqlGraphEntity::Enum(item) if !item.to_sql_config.enabled => Ok(String::default()),
+            SqlGraphEntity::Enum(item) => {
+                if let Some(callback) = item.to_sql_config.callback {
+                    callback(self, context)
+                } else {
+                    item.to_sql(context)
+                }
+            }
+            SqlGraphEntity::Ord(item) if !item.to_sql_config.enabled => Ok(String::default()),
+            SqlGraphEntity::Ord(item) => {
+                if let Some(callback) = item.to_sql_config.callback {
+                    callback(self, context)
+                } else {
+                    item.to_sql(context)
+                }
+            }
+            SqlGraphEntity::Hash(item) if !item.to_sql_config.enabled => Ok(String::default()),
+            SqlGraphEntity::Hash(item) => {
+                if let Some(callback) = item.to_sql_config.callback {
+                    callback(self, context)
+                } else {
+                    item.to_sql(context)
+                }
+            }
+            SqlGraphEntity::Aggregate(item) if !item.to_sql_config.enabled => Ok(String::default()),
+            SqlGraphEntity::Aggregate(item) => {
+                if let Some(callback) = item.to_sql_config.callback {
+                    callback(self, context)
+                } else {
+                    item.to_sql(context)
+                }
+            }
             SqlGraphEntity::ExtensionRoot(item) => item.to_sql(context),
         }
     }


### PR DESCRIPTION
@JamesGuthrie I plan to upstream this, but wanted to get your feedback on it first. Once you've given the thumbs up, I'll open a PR against upstream.

---

This commit introduces a new `#[to_sql]` attribute that allows for
customizing the behavior of SQL generation on certain entities in two
different ways:

1. `#[to_sql(false)]` disables generation of the decorated item's SQL
2. `#[to_sql(path::to::function)]` delegates responsibility for
   generating SQL to the named function

In the latter case, the function has almost the same signature as the
`to_sql` function of the built-in `ToSql` trait, except the function
receives a reference to a `SqlGraphEntity` in place of `&self`. This
allows for extending any of the `SqlGraphEntity` variants using a single
function, as trying to use specific typed functions for each entity type
was deemed overly complex. This also works well with the way `ToSql` is
invoked today, which starts by calling the implementation on a value of
type `SqlGraphEntity`, so we can perform all the checks in a single
place.

As an aside, these custom callbacks can still delegate to the built-in
`ToSql` trait if desired. For example, if you wish to write the
generated SQL for specific entities to a different file.

The motivation for this is that in some edge cases, it is desirable to
elide or modify the SQL being generated. In our case specifically, we
need to chop up the generated SQL so that we can split out non-idempotent
operations separately from idempotent operations in order to properly
manage extension upgrades. Rather than lose the facilities pgx provides,
the `#[to_sql]` attribute allows us to make ad-hoc adjustments to what,
when and where things get generated without needing any upstream support
for those details.